### PR TITLE
refactor: make Mosquitto broker optional via docker-compose.mqtt.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # GoodWe2MQTT environment configuration
 G2M_LOG_LEVEL=INFO
 
-# MQTT Configuration
+# MQTT Broker — point this at your existing broker.
+# If using the bundled Mosquitto via docker-compose.mqtt.yml, keep localhost.
 G2M_MQTT_BROKER_IP=127.0.0.1
 G2M_MQTT_BROKER_PORT=1883
 # G2M_MQTT_USERNAME=

--- a/docker-compose.mqtt.yml
+++ b/docker-compose.mqtt.yml
@@ -1,0 +1,21 @@
+# Optional override: bundled Eclipse Mosquitto MQTT broker.
+#
+# Use this when you do NOT already have an MQTT broker in your setup.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.mqtt.yml up -d
+#
+# Set G2M_MQTT_BROKER_IP=localhost in your .env (host networking is used).
+
+services:
+  mqtt-broker:
+    image: eclipse-mosquitto:2
+    container_name: mqtt-broker
+    restart: unless-stopped
+    ports:
+      - "1883:1883"
+      - "9001:9001"
+    volumes:
+      - ./mosquitto/config:/mosquitto/config
+      - ./mosquitto/data:/mosquitto/data
+      - ./mosquitto/log:/mosquitto/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,20 +6,5 @@ services:
     volumes:
       - ./logs:/app/logs
     env_file: .env
-    # Host networking is often preferred for inverter discovery/communication
-    # but bridge mode with port mapping is more standard for Docker.
-    # For now, using host mode as it's common for IoT/discovery apps.
+    # Host networking is preferred for inverter UDP discovery/communication.
     network_mode: host
-
-  # Optional MQTT Broker (Eclipse Mosquitto)
-  mqtt-broker:
-    image: eclipse-mosquitto:2
-    container_name: mqtt-broker
-    restart: unless-stopped
-    ports:
-      - "1883:1883"
-      - "9001:9001"
-    volumes:
-      - ./mosquitto/config:/mosquitto/config
-      - ./mosquitto/data:/mosquitto/data
-      - ./mosquitto/log:/mosquitto/log

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,6 +7,7 @@ This guide explains how to run `goodwe2mqtt` using Docker and Docker Compose.
 - Docker is the supported deployment path.
 - One container can manage multiple inverters when they are listed in `.env` using indexed `G2M_GOODWE_INVERTERS_<index>_*` variables.
 - Run separate containers only when you intentionally need strict isolation between inverter groups (separate brokers, credentials, networks, or restart policy boundaries).
+- **Most users already have an MQTT broker** (e.g. Home Assistant's Mosquitto add-on). In that case, just point `G2M_MQTT_BROKER_IP` at it and run the daemon only.
 
 ## Prerequisites
 
@@ -15,34 +16,44 @@ This guide explains how to run `goodwe2mqtt` using Docker and Docker Compose.
 
 ## Using Docker Compose (Recommended)
 
-Docker Compose is the easiest way to manage the `goodwe2mqtt` service and an optional MQTT broker.
-
 ### 1. Configure Environment Variables
 
-Copy `.env.example` to `.env` and adjust the values as needed:
+Copy `.env.example` to `.env` and adjust the values:
 
 ```bash
 cp .env.example .env
 ```
 
-Set at least one inverter:
+Set at minimum your broker address and at least one inverter:
 
 ```bash
+G2M_MQTT_BROKER_IP=192.168.1.10   # IP of your existing MQTT broker
 G2M_GOODWE_INVERTERS_0_SERIAL_NUMBER=INV1_SERIAL
 G2M_GOODWE_INVERTERS_0_IP_ADDRESS=192.168.1.100
 ```
 
 Add more inverters by increasing the index (`_1_`, `_2_`, ...).
 
-### 2. Start the Stack
+### 2a. Start — daemon only (recommended for existing setups)
+
+Use this when you already have an MQTT broker (Home Assistant, standalone Mosquitto, etc.):
 
 ```bash
 docker compose up -d
 ```
 
-This will start:
-- `goodwe2mqtt`: The main daemon.
-- `mqtt-broker`: An Eclipse Mosquitto instance (optional, see `docker-compose.yml`).
+This starts only the `goodwe2mqtt` daemon.
+
+### 2b. Start — with bundled Mosquitto broker
+
+Use this when you have no existing MQTT broker and want one included.
+Set `G2M_MQTT_BROKER_IP=localhost` in `.env` (both services share host networking), then:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.mqtt.yml up -d
+```
+
+This starts both `goodwe2mqtt` and an Eclipse Mosquitto instance using the config in `mosquitto/config/mosquitto.conf`.
 
 ### 3. Check Logs
 


### PR DESCRIPTION
## Summary

Most users already have an MQTT broker (Home Assistant Mosquitto add-on, standalone instance, etc.) and don't need or want one bundled. Previously the broker started unconditionally alongside the daemon.

## Changes

- **`docker-compose.yml`** — contains only the `goodwe2mqtt` daemon; `mqtt-broker` removed
- **`docker-compose.mqtt.yml`** *(new)* — Docker Compose override file with the `mqtt-broker` service; opt-in only
- **`.env.example`** — updated broker comment to clarify `localhost` usage with the override
- **`docs/docker.md`** — documents two deployment modes clearly:

### Default (daemon only — existing broker)
```bash
docker compose up -d
```

### With bundled Mosquitto (no existing broker)
```bash
docker compose -f docker-compose.yml -f docker-compose.mqtt.yml up -d
```

The `mosquitto/` config directory is retained and used when the override file is activated.